### PR TITLE
Install cloudinary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@
 # Ignore Mac and Linux file system files
 *.swp
 .DS_Store
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ gem "simple_form", github: "heartcombo/simple_form"
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
-  gem "dotenv-rails"
+  gem "dotenv-rails", groups: %i[ development test ]
 
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -78,5 +78,5 @@ group :test do
   gem "selenium-webdriver"
   gem "webdrivers"
 end
-
+gem "cloudinary"
 gem "faker"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     autoprefixer-rails (10.4.13.0)
       execjs (~> 2)
+    aws_cf_signer (0.1.3)
     bcrypt (3.1.19)
     bindex (0.8.1)
     bootsnap (1.16.0)
@@ -92,6 +93,9 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cloudinary (1.27.0)
+      aws_cf_signer
+      rest-client (>= 2.0.0)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
     date (3.3.3)
@@ -104,6 +108,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.8.1)
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
@@ -117,6 +123,9 @@ GEM
       sassc (~> 2.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    http-accept (1.7.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     io-console (0.6.0)
@@ -138,6 +147,9 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mime-types (3.5.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2023.0808)
     mini_mime (1.1.5)
     minitest (5.19.0)
     msgpack (1.7.2)
@@ -150,6 +162,7 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
+    netrc (0.11.0)
     nio4r (2.5.9)
     nokogiri (1.15.4-x86_64-darwin)
       racc (~> 1.4)
@@ -200,6 +213,11 @@ GEM
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rexml (3.2.6)
     rubyzip (2.3.2)
     sassc (2.4.0)
@@ -232,6 +250,9 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8.2)
     warden (1.2.9)
       rack (>= 2.0.9)
     web-console (4.2.0)
@@ -260,6 +281,7 @@ DEPENDENCIES
   autoprefixer-rails
   bootsnap
   capybara
+  cloudinary
   debug
   devise
   dotenv-rails


### PR DESCRIPTION
I added cloudinary in the gemfile.

I think everyone must do 

touch .env
echo '.env*'  >> .gitignore

I think everyone needs to use their own cloudinary api key + secret ( goto cloudinary dashboard it is there)
then copy paste to .env file.( i will check with the trainers to confirm this.) 

also, remember to run 
bundle install 